### PR TITLE
Add support for carriage return token in lex_contents function

### DIFF
--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -408,7 +408,7 @@ pub mod parse {
         loop {
             match blob.next() {
                 Some(ch) => match ch {
-                    ' ' | '\t' => {
+                    ' ' | '\t' | '\r' => {
                         if block_depth < 2 {
                             push_token(&curr_token, &mut tokens);
                         }


### PR DESCRIPTION
<!--
Thank you for your contribution. Please review below requirements.

Contributors guide: https://github.com/JoshBrudnak/Lojidoc/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] commit message is descriptive
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [x] project builds with no warnings or errors

##### Description of change
<!-- Provide a brief description of the change. -->
Windows has a different new line token ("\r\n") than OSX and Unix ("\n"). I have added a way to process the \r character so that its presence in a file does not cause the program to crash. 
<!-- Reference Links -->
